### PR TITLE
Don't expose platform implementations

### DIFF
--- a/lib/src/imp/tsid.dart
+++ b/lib/src/imp/tsid.dart
@@ -1,30 +1,23 @@
 import 'dart:typed_data';
 
-class Tsid {
-  static Uint8List initializeAlphabetValues() {
+interface class Tsid {
+  Tsid(final BigInt number) {
     throw Exception("Stub implementation");
   }
 
-  static int getNumberFromBytes(Uint8List bytes) {
+  Tsid.fromNumber(final BigInt number);
+
+  Tsid.fromBytes(Uint8List bytes);
+
+  Tsid.fromString(String string);
+
+  BigInt toLong() {
     throw Exception("Stub implementation");
   }
 
-  static int getNumberFromString(String string) {
+  int toInt() {
     throw Exception("Stub implementation");
   }
-
-  Tsid(final int number) {
-    throw Exception("Stub implementation");
-  }
-
-  Tsid.fromNumber(final int number) : this(number);
-
-  Tsid.fromBytes(Uint8List bytes) : this(getNumberFromBytes(bytes));
-
-  Tsid.fromString(String string) : this(getNumberFromString(string));
-
-  int toLong() {
-    throw Exception("Stub implementation");  }
 
   Uint8List toBytes() {
     throw Exception("Stub implementation");
@@ -36,19 +29,24 @@ class Tsid {
 
   @override
   String toString() {
-    throw Exception("Stub implementation");  }
+    throw Exception("Stub implementation");
+  }
 
   String toLowerCase() {
-    throw Exception("Stub implementation");  }
+    throw Exception("Stub implementation");
+  }
 
-  int getUnixMilliseconds(final int customEpoch) {
-    throw Exception("Stub implementation");  }
+  BigInt getUnixMilliseconds(final BigInt customEpoch) {
+    throw Exception("Stub implementation");
+  }
 
-  int getTime() {
-    throw Exception("Stub implementation");  }
+  BigInt getTime() {
+    throw Exception("Stub implementation");
+  }
 
-  int getRandom() {
-    throw Exception("Stub implementation");  }
+  BigInt getRandom() {
+    throw Exception("Stub implementation");
+  }
 
   static bool isValid(final String string) {
     throw Exception("Stub implementation");
@@ -85,7 +83,6 @@ class Tsid {
     throw Exception("Stub implementation");
   }
 
-
   factory Tsid.getTsid() {
     throw Exception("Stub implementation");
   }
@@ -109,5 +106,19 @@ class Tsid {
       return false;
     }
     return super.hashCode == other.hashCode;
+  }
+}
+
+interface class TsidFactory {
+  factory TsidFactory() {
+    throw Exception("Stub implementation");
+  }
+
+  factory TsidFactory.fromNode(BigInt node) {
+    throw Exception("Stub implementation");
+  }
+
+  Tsid create() {
+    throw Exception("Stub implementation");
   }
 }

--- a/lib/src/imp/tsid_native.dart
+++ b/lib/src/imp/tsid_native.dart
@@ -399,9 +399,9 @@ class BaseN {
 }
 
 class _LazyHolder {
-  static const int maxInt = 0x7FFFFFFFFFFFFFFF;
+  static final int maxInt = double.maxFinite.toInt();
 
-  static int counter = Random().nextInt(maxInt);
+  static int counter = (Random().nextDouble() * maxInt).toInt();
 
   static int incrementAndGet() {
     return ++counter;

--- a/lib/src/imp/tsid_web.dart
+++ b/lib/src/imp/tsid_web.dart
@@ -561,7 +561,7 @@ class TsidFactoryBuilder {
   static final _tsidEpoch = Tsid._tsidEpoch;
 
   // error if removed
-  late BigInt? _node;
+  BigInt? _node;
   late BigInt _nodeBits = TsidFactory._nodeBits1024;
   late BigInt _customEpoch = _tsidEpoch;
   late IRandom _random = ByteRandom.fromRandom(Random.secure());

--- a/lib/src/tsid.dart
+++ b/lib/src/tsid.dart
@@ -1,0 +1,88 @@
+import 'dart:typed_data' show Uint8List;
+
+import 'imp/tsid.dart'
+    if (dart.library.io) 'imp/tsid_native.dart'
+    if (dart.library.js_interop) 'imp/tsid_web.dart' as tsid;
+
+class Tsid {
+  final tsid.Tsid _tsid;
+
+  Tsid(BigInt number) : _tsid = tsid.Tsid.fromNumber(number);
+
+  Tsid._(this._tsid);
+
+  factory Tsid.getTsid() {
+    return Tsid._(tsid.Tsid.getTsid());
+  }
+
+  factory Tsid.fromNumber(BigInt number) {
+    return Tsid._(tsid.Tsid.fromNumber(number));
+  }
+
+  factory Tsid.fromString(String string) {
+    return Tsid._(tsid.Tsid.fromString(string));
+  }
+
+  factory Tsid.fast() {
+    return Tsid._(tsid.Tsid.fast());
+  }
+
+  factory Tsid.getTsid1024() {
+    return Tsid._(tsid.Tsid.getTsid1024());
+  }
+
+  factory Tsid.fromBytes(Uint8List bytes) {
+    return Tsid._(tsid.Tsid.fromBytes(bytes));
+  }
+
+  int compareTo(Tsid that) {
+    return _tsid.compareTo(that._tsid);
+  }
+
+  @override
+  operator ==(Object other) {
+    if (other is! Tsid) {
+      return false;
+    }
+
+    return _tsid == other._tsid;
+  }
+
+  BigInt toLong() {
+    return _tsid.toLong();
+  }
+
+  int toInt() {
+    return _tsid.toInt();
+  }
+
+  Uint8List toBytes() {
+    return _tsid.toBytes();
+  }
+
+  @override
+  String toString() {
+    return _tsid.toString();
+  }
+
+  @override
+  int get hashCode => _tsid.hashCode;
+}
+
+class TsidFactory {
+  final tsid.TsidFactory _factory;
+
+  TsidFactory._(this._factory);
+
+  factory TsidFactory() {
+    return TsidFactory._(tsid.TsidFactory());
+  }
+
+  factory TsidFactory.fromNode(BigInt node) {
+    return TsidFactory._(tsid.TsidFactory.fromNode(node));
+  }
+
+  Tsid create() {
+    return Tsid._(_factory.create());
+  }
+}

--- a/lib/tsid_dart.dart
+++ b/lib/tsid_dart.dart
@@ -1,9 +1,4 @@
-/// Support for doing something awesome.
-///
-/// More dartdocs go here.
 library;
 
-export 'src/tsid_stub.dart'
-    if (dart.library.io) 'src/tsid_default.dart'
-    if (dart.library.html) 'src/tsid_web.dart';
+export 'src/tsid.dart' show Tsid, TsidFactory;
 export 'src/tsid_error.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tsid_dart
 description: A TSID Port for Dart libraries or applications. it probably possible to run on any platform, however it was tested on macos and web only.
-version: 0.0.5
+version: 0.1.0
 repository: https://github.com/goeo1066/tsid_dart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,12 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  # path: ^1.8.0
-  decimal: ^2.3.3
+  decimal: ^3.2.4
   collection: ^1.18.0
   convert: ^3.1.1
 
 dev_dependencies:
-  lints: ^2.1.0
+  lints: ^6.0.0
   test: ^1.24.0
 
 platforms:

--- a/test/tsid_test.dart
+++ b/test/tsid_test.dart
@@ -18,11 +18,15 @@ void main() {
     test('testFromBytes', () {
       for (int i = 0; i < loopMax; i++) {
         final int number0 = Random().nextInt(maxLong);
-        final ByteData buffer = ByteData(8);
-        buffer.setInt64(0, number0);
-        Uint8List bytes = buffer.buffer.asUint8List();
 
-        final int number1 = Tsid.fromBytes(bytes).toLong();
+        final ByteData buffer = ByteData(8);
+
+        buffer.setInt64(0, number0);
+
+        final Uint8List bytes = buffer.buffer.asUint8List();
+
+        final int number1 = Tsid.fromBytes(bytes).toInt();
+
         assert(number0 == number1);
       }
     });
@@ -45,7 +49,7 @@ void main() {
       for (int i = 0; i < loopMax; i++) {
         final int number0 = Random().nextInt(maxLong);
         final String string0 = toString(number0);
-        final int number1 = Tsid.fromString(string0).toLong();
+        final int number1 = Tsid.fromString(string0).toInt();
         assert(number0 == number1);
       }
     });
@@ -53,8 +57,11 @@ void main() {
     test('testToString', () {
       for (int i = 0; i < loopMax; i++) {
         final int number = Random().nextInt(maxLong);
+
         final String string0 = toString(number);
-        final String string1 = Tsid.fromNumber(number).toString();
+
+        final String string1 = Tsid.fromNumber(BigInt.from(number)).toString();
+
         assert(string0 == string1);
       }
     });
@@ -63,8 +70,8 @@ void main() {
       test('equal number', () {
         for (int i = 0; i < loopMax; i++) {
           final int number = Random().nextInt(maxLong);
-          final Tsid tsid1 = Tsid.fromNumber(number);
-          final Tsid tsid2 = Tsid.fromNumber(number);
+          final Tsid tsid1 = Tsid.fromNumber(BigInt.from(number));
+          final Tsid tsid2 = Tsid.fromNumber(BigInt.from(number));
           assert(tsid1 == tsid2);
         }
       });
@@ -73,8 +80,8 @@ void main() {
         for (int i = 0; i < loopMax; i++) {
           final int number1 = Random().nextInt(maxLong);
           final int number2 = Random().nextInt(maxLong);
-          final Tsid tsid1 = Tsid.fromNumber(number1);
-          final Tsid tsid2 = Tsid.fromNumber(number2);
+          final Tsid tsid1 = Tsid.fromNumber(BigInt.from(number1));
+          final Tsid tsid2 = Tsid.fromNumber(BigInt.from(number2));
           assert(tsid1 != tsid2);
         }
       });


### PR DESCRIPTION
Hello 😁 

The conditional export causes problems in the imports' resolution because the implementations didn't share a common interface. In order to resolve that, I hid the platforms implementations behind an abstraction that conditionally imports the implementations.
I also added some fixes to the web implementation in the `fromString` and `fromBytes` constructors, they were using `int`s instead of `BigInt`s.

This introduces breaking changes because I introduced a common interface,  replacing the `int`s for `BigInt`s in all constructors.